### PR TITLE
chore: bump golang to 1.23.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.5'
+          go-version: '1.23.6'
 
       - name: make verify
         run: make verify

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.5'
+          go-version: '1.23.6'
 
       - name: release
         run: make release

--- a/demo/app/go.mod
+++ b/demo/app/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/bavarianbidi/kubectl-dpm/demo/app
 
-go 1.23.5
+go 1.23.6
 
 require github.com/prometheus/client_golang v1.19.1
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/bavarianbidi/kubectl-dpm
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/knadh/koanf v1.5.0


### PR DESCRIPTION
bumping golang to resolve https://pkg.go.dev/vuln/GO-2025-3447 which we never hit as we do not build for ppc64le.

but as govulncheck doesn't have support for an ignore file, let's bump the golang itself - sooner or later it was requried in any case