### PR TITLE
chore: bump golang to 1.26.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: make verify
         run: make verify

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: release
         run: make release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 # kubectl-dpm Developer Notes
 
-`kubectl-dpm` is a kubectl plugin for managing Kubernetes debug profiles. Written in Go 1.26.2.
+`kubectl-dpm` is a kubectl plugin for managing Kubernetes debug profiles. Written in Go 1.26.3.
 
 ## Commands
 

--- a/demo/app/go.mod
+++ b/demo/app/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/bavarianbidi/kubectl-dpm/demo/app
 
-go 1.26.2
+go 1.26.3
 
 require github.com/prometheus/client_golang v1.19.1
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/bavarianbidi/kubectl-dpm
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/knadh/koanf v1.5.0


### PR DESCRIPTION
fix govulncheck discovered vulnerabilities:

Vulnerability #1: GO-2026-4971
Vulnerability #2: GO-2026-4918