### PR TITLE
fix: pass context from main to background ops

### DIFF
--- a/cmd/kubectl-dpm.go
+++ b/cmd/kubectl-dpm.go
@@ -16,7 +16,14 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
 
 	flags := pflag.NewFlagSet("kubectl-dpm", pflag.ExitOnError)
 	pflag.CommandLine = flags
@@ -45,9 +52,5 @@ func main() {
 	// version sub command
 	root.AddCommand(command.Version())
 
-	err := root.ExecuteContext(ctx)
-	stop()
-	if err != nil {
-		os.Exit(1)
-	}
+	return root.ExecuteContext(ctx)
 }

--- a/pkg/command/interactive.go
+++ b/pkg/command/interactive.go
@@ -3,6 +3,8 @@
 package command
 
 import (
+	"context"
+
 	bubbletable "github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -15,9 +17,9 @@ type model struct {
 }
 
 // initTeaModel initializes the model for the interactive mode
-func initTeaModel() (model, error) {
+func initTeaModel(ctx context.Context) (model, error) {
 	// generate a list of profiles which work in interactive mode
-	interactiveProfiles, err := profile.InteractiveProfiles()
+	interactiveProfiles, err := profile.InteractiveProfiles(ctx)
 	if err != nil {
 		return model{}, err
 	}

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -40,7 +40,7 @@ func NewCmdDebugProfile(_ genericiooptions.IOStreams) *cobra.Command {
 
 			// if no profile flag is set, start interactive mode to select a profile
 			if !c.Flags().Changed(profileFlagName) {
-				model, err := initTeaModel()
+				model, err := initTeaModel(c.Context())
 				if err != nil {
 					return fmt.Errorf("run debug command: %w", err)
 				}
@@ -95,7 +95,7 @@ func run(ctx context.Context, args []string) error {
 	}
 
 	// validate profile
-	if err := profile.ValidateProfile(flagProfileName); err != nil {
+	if err := profile.ValidateProfile(ctx, flagProfileName); err != nil {
 		return fmt.Errorf("complete profile %q: %w", flagProfileName, err)
 	}
 
@@ -120,7 +120,7 @@ func run(ctx context.Context, args []string) error {
 		}
 
 		// Inject the client and validate the ConfigMap source
-		if err := profile.InitializeConfigMapSource(&debugProfile, clientset); err != nil {
+		if err := profile.InitializeConfigMapSource(ctx, &debugProfile, clientset); err != nil {
 			return fmt.Errorf("initialize configmap source: %w", err)
 		}
 		profile.Config.Profiles[idx] = debugProfile

--- a/pkg/command/validate.go
+++ b/pkg/command/validate.go
@@ -16,12 +16,12 @@ func ValidateDebugProfileFile() *cobra.Command {
 		Use:   "validate",
 		Short: "validate debug profiles configuration file",
 
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(c *cobra.Command, _ []string) error {
 			if err := config.GenerateConfig(); err != nil {
 				return fmt.Errorf("generate config: %w", err)
 			}
 
-			if err := profile.ValidateAllProfiles(); err != nil {
+			if err := profile.ValidateAllProfiles(c.Context()); err != nil {
 				return fmt.Errorf("validate profiles: %w", err)
 			}
 

--- a/pkg/profile/validate.go
+++ b/pkg/profile/validate.go
@@ -17,12 +17,12 @@ import (
 	kubectldebug "k8s.io/kubectl/pkg/cmd/debug"
 )
 
-func ValidateDebugProfileFile() error {
+func ValidateDebugProfileFile(ctx context.Context) error {
 	if err := ValidateKubectlPath(); err != nil {
 		return fmt.Errorf("validate kubectl path: %w", err)
 	}
 
-	if err := ValidateAllProfiles(); err != nil {
+	if err := ValidateAllProfiles(ctx); err != nil {
 		return fmt.Errorf("validate all profiles: %w", err)
 	}
 
@@ -54,7 +54,7 @@ func ValidateKubectlPath() error {
 	return nil
 }
 
-func ValidateAllProfiles() error {
+func ValidateAllProfiles(ctx context.Context) error {
 	// sort profiles by name
 	SortProfiles()
 
@@ -79,7 +79,7 @@ func ValidateAllProfiles() error {
 			return fmt.Errorf("profile %q is missing both profileSource and profile (legacy) configuration", p.ProfileName)
 		}
 
-		if err := ValidateProfile(p.ProfileName); err != nil {
+		if err := ValidateProfile(ctx, p.ProfileName); err != nil {
 			return fmt.Errorf("validate profile %q: %w", p.ProfileName, err)
 		}
 	}
@@ -87,7 +87,7 @@ func ValidateAllProfiles() error {
 }
 
 // ValidateProfile validates a single profile and instantiates its ProfileSource
-func ValidateProfile(profileName string) error {
+func ValidateProfile(ctx context.Context, profileName string) error {
 	idx, err := GetProfileIdx(profileName)
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func ValidateProfile(profileName string) error {
 	// Check if using new ProfileSource config or legacy Profile field
 	if profile.ProfileSource.Type != "" {
 		// New ProfileSource configuration
-		return validateAndInstantiateProfileSource(profile, nil)
+		return validateAndInstantiateProfileSource(ctx, profile, nil)
 	}
 
 	// Legacy Profile field - handle for backward compatibility
@@ -111,7 +111,7 @@ func ValidateProfile(profileName string) error {
 // validateAndInstantiateProfileSource creates the appropriate ProfileSource implementation
 // based on the ProfileSourceConfig. The k8sClient parameter is optional and only needed
 // for ConfigMap sources.
-func validateAndInstantiateProfileSource(p *Profile, k8sClient corev1client.CoreV1Interface) error {
+func validateAndInstantiateProfileSource(ctx context.Context, p *Profile, k8sClient corev1client.CoreV1Interface) error {
 	var source ProfileSource
 	var err error
 
@@ -178,7 +178,7 @@ func validateAndInstantiateProfileSource(p *Profile, k8sClient corev1client.Core
 
 	// Validate by fetching the spec (except for ConfigMap during initial validation)
 	if p.ProfileSource.Type != SourceTypeConfigMap {
-		_, err = source.GetSpec(context.Background())
+		_, err = source.GetSpec(ctx)
 		if err != nil {
 			log.Printf("profile %s validation warning: %s\n", p.ProfileName, err.Error())
 		}
@@ -220,11 +220,11 @@ func validateLegacyProfile(idx int) error {
 // InteractiveProfiles returns all profiles that can be used from
 // the interactive mode, dpm run (without args)
 // these profiles do have all required fields set (namespace, labelSelector, image)
-func InteractiveProfiles() ([]Profile, error) {
+func InteractiveProfiles(ctx context.Context) ([]Profile, error) {
 	// sort profiles by name
 	SortProfiles()
 
-	err := ValidateAllProfiles()
+	err := ValidateAllProfiles(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("validate all profiles: %w", err)
 	}
@@ -314,7 +314,7 @@ func CompleteStyle() {
 
 // InitializeConfigMapSource creates and sets a ConfigMapProfileSource with the given Kubernetes client.
 // This function must be called at runtime before using a ConfigMap profile source.
-func InitializeConfigMapSource(p *Profile, client corev1client.CoreV1Interface) error {
+func InitializeConfigMapSource(ctx context.Context, p *Profile, client corev1client.CoreV1Interface) error {
 	if p.ProfileSource.Type != SourceTypeConfigMap {
 		return fmt.Errorf("profile is not a configmap source")
 	}
@@ -327,7 +327,7 @@ func InitializeConfigMapSource(p *Profile, client corev1client.CoreV1Interface) 
 	p.SetSource(source)
 
 	// Validate by fetching the spec
-	_, err := source.GetSpec(context.Background())
+	_, err := source.GetSpec(ctx)
 	if err != nil {
 		return fmt.Errorf("validate configmap source: %w", err)
 	}

--- a/pkg/profile/validate_test.go
+++ b/pkg/profile/validate_test.go
@@ -3,6 +3,7 @@
 package profile
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"testing"
@@ -171,7 +172,7 @@ func TestValidateAllProfiles(t *testing.T) {
 			// set the global Config variable to the test config
 			Config = tt.config
 
-			if err := ValidateAllProfiles(); (err != nil) != tt.wantErr {
+			if err := ValidateAllProfiles(context.Background()); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateAllProfiles() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && !reflect.DeepEqual(tt.wantedConfig, Config) {
@@ -289,7 +290,7 @@ func TestCompleteProfile(t *testing.T) {
 			},
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ValidateProfile(tt.profileName); (err != nil) != tt.wantErr {
+			if err := ValidateProfile(context.Background(), tt.profileName); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateProfile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if err := CompleteProfile(tt.profileName); (err != nil) != tt.wantErr {


### PR DESCRIPTION
as `getSpec` became a slow operation, main ctx should get passed down the road